### PR TITLE
17 error catching when calculating summary statistics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyelq-sdk"
-version = "1.0.10"
+version = "1.0.11"
 description = "Package for detection, localization and quantification code."
 authors = ["Bas van de Kerkhof", "Matthew Jones", "David Randell"]
 homepage = "https://sede-open.github.io/pyELQ/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ addopts = "--cov=pyelq --cov-fail-under=90 --ignore-glob=*plot*"
 testpaths = ["tests"]
 
 [tool.coverage.report]
-omit = ["*plot*", "*/data_access/*", "*/plotting/*", "*/post_processing/*"]
+omit = ["*plot*", "*/data_access/*", "*/plotting/*", "*post_processing*"]
 exclude_lines = [".*def.*plot.*", "from pyelq.plotting.plot import Plot"]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Bugfix when no sources are present in the z_src array. We now account for that in the code and make sure the code does not brake down the line in the plotting.

Fixes #17 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Jupyter Notebooks

No changes in notebooks.

# How Has This Been Tested?

Tested by running the support_functions`post_processing.calculate_rectangular_statistics(<INPUTS>)` and `plotting.plot.plot_quantification_results_on_map(<INPUTS>)` methods on saved files which both do and do not contain values in z_src.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

