### PR TITLE
Expose random walk step size as a parameter in source_model.py

### DIFF
--- a/.github/workflows/sonarcloud_analysis.yml
+++ b/.github/workflows/sonarcloud_analysis.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: pytest_junitxml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyelq-sdk"
-version = "1.0.11"
+version = "1.0.12"
 description = "Package for detection, localization and quantification code."
 authors = ["Bas van de Kerkhof", "Matthew Jones", "David Randell"]
 homepage = "https://sede-open.github.io/pyELQ/"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,4 @@ sonar.python.coveragePlugin=cobertura
 sonar.python.xunit.reportPath=pytest_junit.xml
 sonar.tests=tests
 sonar.sourceEncoding=UTF-8
-sonar.coverage.exclusions=*/pyelq/data_access/*.*, */pyelq/plotting/*.*
+sonar.coverage.exclusions=*/pyelq/data_access/*.*, */pyelq/plotting/*.*, */pyelq/support_functions/post_processing.py

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -425,6 +425,8 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
 
         reversible_jump (bool): logical indicating whether the reversible jump algorithm for estimation of the number
             of sources and their locations should be run. Defaults to False.
+        random_walk_step_size (np.ndarray): (3 x 1) array specifying the standard deviations of the distributions
+            from which the random walk sampler draws new source locations. Defaults to np.array([1.0, 1.0, 0.1])
         site_limits (np.ndarray): (3 x 2) array specifying the lower (column 0) and upper (column 1) limits of the
             analysis site. Only relevant for cases where reversible_jump == True (where sources are free to move in
             the solution).
@@ -462,6 +464,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
     gas_species: GasSpecies = field(init=False, default=None)
 
     reversible_jump: bool = False
+    random_walk_step_size: np.ndarray = field(default_factory=lambda: np.array([1.0, 1.0, 0.1], ndmin=2).T)
     site_limits: np.ndarray = None
     rate_num_sources: int = 5
     n_sources_max: int = 20
@@ -788,7 +791,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
             RandomWalkLoop(
                 "z_src",
                 model,
-                step=np.array([1.0, 1.0, 0.1], ndmin=2).T,
+                step=self.random_walk_step_size,
                 max_variable_size=(3, self.n_sources_max),
                 domain_limits=self.site_limits,
                 state_update_function=self.move_function,

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -426,7 +426,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         reversible_jump (bool): logical indicating whether the reversible jump algorithm for estimation of the number
             of sources and their locations should be run. Defaults to False.
         random_walk_step_size (np.ndarray): (3 x 1) array specifying the standard deviations of the distributions
-            from which the random walk sampler draws new source locations. Defaults to np.array([1.0, 1.0, 0.1])
+            from which the random walk sampler draws new source locations. Defaults to np.array([1.0, 1.0, 0.1]).
         site_limits (np.ndarray): (3 x 2) array specifying the lower (column 0) and upper (column 1) limits of the
             analysis site. Only relevant for cases where reversible_jump == True (where sources are free to move in
             the solution).


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Shell Global Solutions International B.V. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0
-->

# Description

Previously, `RandomWalkLoop` had a fixed step size of (1, 1, 0.1). It was discussed that larger step sizes could be more appropriate for larger sites. This pull request exposes these as parameters of the source model. The default values are still the same as they were before.

Fixes #7 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested with step size = (0, 0, 0) with example notebook and observed inability of model to fit to data.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

