### PR TITLE
minor bug fix to account for the cases with one source when creating lla_polygons_from_xy_points

### DIFF
--- a/src/pyelq/support_functions/post_processing.py
+++ b/src/pyelq/support_functions/post_processing.py
@@ -229,6 +229,11 @@ def create_lla_polygons_from_xy_points(
     _, gridsize_lat = is_regularly_spaced(lla_object_full_grid.latitude, tolerance=1e-6)
     _, gridsize_lon = is_regularly_spaced(lla_object_full_grid.longitude, tolerance=1e-6)
 
+    if np.isnan(gridsize_lat):
+        gridsize_lat = 1e-6
+    if np.isnan(gridsize_lon):
+        gridsize_lon = 1e-6
+
     polygons = [
         geometry.box(
             lla_object_full_grid.longitude[idx] - gridsize_lon / 2,

--- a/src/pyelq/support_functions/post_processing.py
+++ b/src/pyelq/support_functions/post_processing.py
@@ -197,7 +197,8 @@ def create_lla_polygons_from_xy_points(
 
     This function takes a grid of East-North points, these points are used as center points for a pixel grid. The pixel
     grid is then converted to LLA coordinates and these center points are used to create a polygon in LLA coordinates.
-    A polygon is only created if the boolean mask for that pixel is True.
+    A polygon is only created if the boolean mask for that pixel is True. In case one East-North point is available, a 
+    predefined grid size of 1e-6 (equaling to 0.0036 seconds)
 
     Args:
         points_array (list[np.ndarray]): List of arrays of grid of points in ENU coordinates.

--- a/src/pyelq/support_functions/post_processing.py
+++ b/src/pyelq/support_functions/post_processing.py
@@ -198,7 +198,7 @@ def create_lla_polygons_from_xy_points(
     This function takes a grid of East-North points, these points are used as center points for a pixel grid. The pixel
     grid is then converted to LLA coordinates and these center points are used to create a polygon in LLA coordinates.
     A polygon is only created if the boolean mask for that pixel is True. In case one unique East-North point is
-    available, a predefined grid size of 1e-6 (equaling to 0.0036 seconds) is assumed. 
+    available, a predefined grid size of 1e-6 (equaling to 0.0036 seconds) is assumed.
 
     Args:
         points_array (list[np.ndarray]): List of arrays of grid of points in ENU coordinates.

--- a/src/pyelq/support_functions/post_processing.py
+++ b/src/pyelq/support_functions/post_processing.py
@@ -197,8 +197,8 @@ def create_lla_polygons_from_xy_points(
 
     This function takes a grid of East-North points, these points are used as center points for a pixel grid. The pixel
     grid is then converted to LLA coordinates and these center points are used to create a polygon in LLA coordinates.
-    A polygon is only created if the boolean mask for that pixel is True. In case one East-North point is available, a 
-    predefined grid size of 1e-6 (equaling to 0.0036 seconds)
+    A polygon is only created if the boolean mask for that pixel is True. In case one unique East-North point is
+    available, a predefined grid size of 1e-6 (equaling to 0.0036 seconds) is assumed. 
 
     Args:
         points_array (list[np.ndarray]): List of arrays of grid of points in ENU coordinates.


### PR DESCRIPTION
# Description

This bugfix is implemented in the create_lla_polygons_from_xy_points function in the post_processing class to account for the situations where one unique East-North point exists. In this situation gridsize_lat and (or) gridsize_lon which are the outputs from is_regularly_spaced are Nan and therefore the polygons cannot be created. To address this issue, the gridsize_lat  and gridsize_lon are checked and if either of them are Nan, a predefined gridsize_lat  and gridsize_lon of 1e-6 (equaling 0.0036 seconds) is used. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Jupyter Notebooks

No changes to notebooks.

# How Has This Been Tested?

No new test is needed. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

