### PR TITLE
adding the functionality for fixed and reversible jump 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyelq-sdk"
-version = "1.0.12"
+version = "1.0.13"
 description = "Package for detection, localization and quantification code."
 authors = ["Bas van de Kerkhof", "Matthew Jones", "David Randell"]
 homepage = "https://sede-open.github.io/pyELQ/"

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -19,7 +19,7 @@ A SourceModel instance inherits from 3 super-classes:
 from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Tuple, Union, Dict
+from typing import TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 from openmcmc import parameter

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -44,36 +44,35 @@ if TYPE_CHECKING:
 @dataclass
 class ParameterMapping:
     """ Class for defining mapping variable/parameterised labels needed for creating an mcmc
+        Args:
+        label_string (str): string to append to the parameter mapping, e.g. for fixed sources.
 
     """
-    map : Dict = field(default_factory==
-                      {'source': 's',
-                       'coupling_matrix': 'A',
-                        'emission_rate_mean':'mu_s',
-                        'emission_rate_precision': 'lambda_s',
-                        'allocation': 'alloc_s',
-                        'source_prob': 's_prob',
-                        'precision_prior_shape': 'a_lam_s',
-                        'precision_prior_rate': 'b_lam_s',
-                        "source_location": 'z_src',
-                        'number_sources': 'n_src',
-                        "number_source_rate": 'rho'})
-                      
-    def append_string(self, string: str=None):
-        """ Append string to all element of map
+    label_string: str = None    
 
-        e.g. 'source': 's' would become 'source': 's_fixed' with string = 'fixed'
+    _map ={'source': 's',
+        'coupling_matrix': 'A',
+        'emission_rate_mean':'mu_s',
+        'emission_rate_precision': 'lambda_s',
+        'allocation': 'alloc_s',
+        'source_prob': 's_prob',
+        'precision_prior_shape': 'a_lam_s',
+        'precision_prior_rate': 'b_lam_s',
+        "source_location": 'z_src',
+        'number_sources': 'n_src',
+        "number_source_rate": 'rho'}
 
-        If string is None nothing is appended
+    @property
+    def map(self) -> Dict[str, str]:
 
-        Args:
-            string (str): string to append
-        """
-        if string is None:
-            return
+        if self.label_string is None:
+            return self._map
+        else:
+            mapping_dictionary = {}
+            for key, value in self._map.items():
+                mapping_dictionary[key] = value + '_' + self.label_string
+            return mapping_dictionary
 
-        for key, value in self.map.items():
-            self.map[key] = value + '_' + string
 
 @dataclass
 class SourceGrouping(ParameterMapping):
@@ -488,7 +487,6 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         threshold_function (Callable): Callable function which returns a single value that defines the threshold
             for the coupling in a lambda function form. Examples: lambda x: np.quantile(x, 0.95, axis=0),
             lambda x: np.max(x, axis=0), lambda x: np.mean(x, axis=0). Defaults to np.quantile.
-        label_string (str): string to append to the parameter mapping, e.g. for fixed sources.
     """
 
     dispersion_model: GaussianPlume = field(init=False, default=None)
@@ -516,11 +514,6 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
 
     threshold_function: callable = lambda x: np.quantile(x, 0.95, axis=0)
 
-    label_string: str = None 
-
-    def __post_init__(self):
-        if self.label_string is not None:
-            self.append_string(self.label_string)
 
     @property
     def nof_sources(self):

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -41,9 +41,41 @@ from pyelq.source_map import SourceMap
 if TYPE_CHECKING:
     from pyelq.plotting.plot import Plot
 
+@dataclass
+class ParameterMapping:
+    """ Class for defining mapping variable/parameterised labels needed for creating an mcmc
+
+    """
+    map = {'source': 's',
+           'coupling_matrix': 'A',
+           'emission_rate_mean':'mu_s',
+           'emission_rate_precision': 'lambda_s',
+           'allocation': 'alloc_s',
+           'source_prob': 's_prob',
+           'precision_prior_shape': 'a_lam_s',
+           'precision_prior_rate': 'b_lam_s',
+           "source_location": 'z_src',
+           'number_sources': 'n_src',
+           "number_source_rate": 'rho'}
+
+    def append_string(self, string: str=None):
+        """ Append string to all element of map
+
+        e.g. 'source': 's' would become 'source': 's_fixed' with string = 'fixed'
+
+        If string is None nothing is appended
+
+        Args:
+            string (str): string to append
+        """
+        if string is None:
+            return
+
+        for key, value in self.map.items():
+            self.map[key] = value + '_' + string
 
 @dataclass
-class SourceGrouping:
+class SourceGrouping(ParameterMapping):
     """Superclass for source grouping approach.
 
     Source grouping method determines the group allocation of each source in the model, e.g: slab and spike
@@ -52,13 +84,11 @@ class SourceGrouping:
     Attributes:
         nof_sources (int): number of sources in the model.
         emission_rate_mean (Union[float, np.ndarray]): prior mean parameter for the emission rate distribution.
-        _source_key (str): label for the source parameter to be used in the distributions, samplers, MCMC state etc.
 
     """
 
     nof_sources: int = field(init=False)
     emission_rate_mean: Union[float, np.ndarray] = field(init=False)
-    _source_key: str = field(init=False, default="s")
 
     @abstractmethod
     def make_allocation_model(self, model: list) -> list:
@@ -163,8 +193,8 @@ class NullGrouping(SourceGrouping):
             dict: state updated with parameters related to the source grouping.
 
         """
-        state["mu_s"] = np.array(self.emission_rate_mean, ndmin=1)
-        state["alloc_s"] = np.zeros((self.nof_sources, 1), dtype="int")
+        state[self.map['emission_rate_mean']] = np.array(self.emission_rate_mean, ndmin=1)
+        state[self.map["allocation"]] = np.zeros((self.nof_sources, 1), dtype="int")
         return state
 
     def from_mcmc_group(self, store: dict):
@@ -206,7 +236,7 @@ class SlabAndSpike(SourceGrouping):
             list: overall model list, updated with allocation distribution.
 
         """
-        model.append(Categorical("alloc_s", prob="s_prob"))
+        model.append(Categorical(self.map["allocation"], prob=self.map["source_prob"]))
         return model
 
     def make_allocation_sampler(self, model: Model, sampler_list: list) -> list:
@@ -220,7 +250,8 @@ class SlabAndSpike(SourceGrouping):
             list: sampler_list updated with sampler for the source allocation.
 
         """
-        sampler_list.append(MixtureAllocation(param="alloc_s", model=model, response_param=self._source_key))
+        sampler_list.append(MixtureAllocation(param=self.map["allocation"], model=model,
+                                              response_param=self.map["source"]))
         return sampler_list
 
     def make_allocation_state(self, state: dict) -> dict:
@@ -233,9 +264,10 @@ class SlabAndSpike(SourceGrouping):
             dict: state updated with parameters related to the source grouping.
 
         """
-        state["mu_s"] = np.array(self.emission_rate_mean, ndmin=1)
-        state["s_prob"] = np.tile(np.array([self.slab_probability, 1 - self.slab_probability]), (self.nof_sources, 1))
-        state["alloc_s"] = np.ones((self.nof_sources, 1), dtype="int")
+        state[self.map["emission_rate_mean"]] = np.array(self.emission_rate_mean, ndmin=1)
+        state[self.map["source_prob"]] = np.tile(np.array([self.slab_probability, 1 - self.slab_probability]),
+                                                 (self.nof_sources, 1))
+        state[self.map["allocation"]] = np.ones((self.nof_sources, 1), dtype="int")
         return state
 
     def from_mcmc_group(self, store: dict):
@@ -245,11 +277,11 @@ class SlabAndSpike(SourceGrouping):
             store (dict): dictionary containing samples from the MCMC.
 
         """
-        self.allocation = store["alloc_s"]
+        self.allocation = store[self.map["allocation"]]
 
 
 @dataclass
-class SourceDistribution:
+class SourceDistribution(ParameterMapping):
     """Superclass for source emission rate distribution.
 
     Source distribution determines the type of prior to be used for the source emission rates, and the transformation
@@ -349,9 +381,11 @@ class NormalResponse(SourceDistribution):
 
         model.append(
             mcmcNormal(
-                "s",
-                mean=parameter.MixtureParameterVector(param="mu_s", allocation="alloc_s"),
-                precision=parameter.MixtureParameterMatrix(param="lambda_s", allocation="alloc_s"),
+                self.map["source"],
+                mean=parameter.MixtureParameterVector(param=self.map['emission_rate_mean'],
+                                                      allocation=self.map["allocation"]),
+                precision=parameter.MixtureParameterMatrix(param=self.map["emission_rate_precision"],
+                                                           allocation=self.map["allocation"]),
                 domain_response_lower=domain_response_lower,
             )
         )
@@ -370,7 +404,7 @@ class NormalResponse(SourceDistribution):
         """
         if sampler_list is None:
             sampler_list = []
-        sampler_list.append(NormalNormal("s", model))
+        sampler_list.append(NormalNormal(self.map["source"], model))
         return sampler_list
 
     def make_source_state(self, state: dict) -> dict:
@@ -383,7 +417,7 @@ class NormalResponse(SourceDistribution):
             dict: state updated with initial emission rate vector.
 
         """
-        state["s"] = np.zeros((self.nof_sources, 1))
+        state[self.map["source"]] = np.zeros((self.nof_sources, 1))
         return state
 
     def from_mcmc_dist(self, store: dict):
@@ -393,7 +427,7 @@ class NormalResponse(SourceDistribution):
             store (dict): dictionary containing samples from the MCMC.
 
         """
-        self.emission_rate = store["s"]
+        self.emission_rate = store[self.map["source"]]
 
 
 @dataclass
@@ -583,15 +617,16 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
             state (dict): state dictionary containing updated coupling information.
 
         """
-        self.dispersion_model.source_map.location.from_array(state["z_src"][:, [update_column]].T)
+        self.dispersion_model.source_map.location.from_array(state[self.map["source_location"]][:, [update_column]].T)
         new_coupling = self.dispersion_model.compute_coupling(
             self.sensor_object, self.meteorology, self.gas_species, output_stacked=True, run_interpolation=False
         )
 
-        if update_column == state["A"].shape[1]:
-            state["A"] = np.concatenate((state["A"], new_coupling), axis=1)
-        elif update_column < state["A"].shape[1]:
-            state["A"][:, [update_column]] = new_coupling
+        if update_column == state[self.map["coupling_matrix"]].shape[1]:
+            state[self.map["coupling_matrix"]] = np.concatenate((state[self.map["coupling_matrix"]], new_coupling),
+                                                                axis=1)
+        elif update_column < state[self.map["coupling_matrix"]].shape[1]:
+            state[self.map["coupling_matrix"]][:, [update_column]] = new_coupling
         else:
             raise ValueError("Invalid column specification for updating.")
         return state
@@ -629,10 +664,11 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
                 (i.e. log[p(current | proposed)])
 
         """
-        prop_state = self.update_coupling_column(prop_state, int(prop_state["n_src"]) - 1)
-        prop_state["alloc_s"] = np.concatenate((prop_state["alloc_s"], np.array([0], ndmin=2)), axis=0)
+        prop_state = self.update_coupling_column(prop_state, int(prop_state[self.map["number_sources"]]) - 1)
+        prop_state[self.map["allocation"]] = np.concatenate((prop_state[self.map["allocation"]],
+                                                             np.array([0], ndmin=2)), axis=0)
         in_cov_area = self.dispersion_model.compute_coverage(
-            prop_state["A"][:, -1],
+            prop_state[self.map["coupling_matrix"]][:, -1],
             coverage_threshold=self.coverage_threshold,
             threshold_function=self.threshold_function,
         )
@@ -644,8 +680,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
 
         return prop_state, logp_pr_g_cr, logp_cr_g_pr
 
-    @staticmethod
-    def death_function(current_state: dict, prop_state: dict, deletion_index: int) -> Tuple[dict, float, float]:
+    def death_function(self, current_state: dict, prop_state: dict, deletion_index: int) -> Tuple[dict, float, float]:
         """Update MCMC state based on source death proposal.
 
         Proposed state updated as follows:
@@ -669,8 +704,9 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
                 (i.e. log[p(current | proposed)])
 
         """
-        prop_state["A"] = np.delete(prop_state["A"], obj=deletion_index, axis=1)
-        prop_state["alloc_s"] = np.delete(prop_state["alloc_s"], obj=deletion_index, axis=0)
+        prop_state[self.map["coupling_matrix"]] = np.delete(prop_state[self.map["coupling_matrix"]],
+                                                            obj=deletion_index, axis=1)
+        prop_state[self.map["allocation"]] = np.delete(prop_state[self.map["allocation"]], obj=deletion_index, axis=0)
         logp_pr_g_cr = 0.0
         logp_cr_g_pr = 0.0
 
@@ -693,7 +729,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         prop_state = deepcopy(current_state)
         prop_state = self.update_coupling_column(prop_state, update_column)
         in_cov_area = self.dispersion_model.compute_coverage(
-            prop_state["A"][:, update_column],
+            prop_state[self.map["coupling_matrix"]][:, update_column],
             coverage_threshold=self.coverage_threshold,
             threshold_function=self.threshold_function,
         )
@@ -714,16 +750,18 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         model = self.make_allocation_model(model)
         model = self.make_source_model(model)
         if self.update_precision:
-            model.append(Gamma("lambda_s", shape="a_lam_s", rate="b_lam_s"))
+            model.append(Gamma(self.map["emission_rate_precision"],
+                               shape=self.map["precision_prior_shape"],
+                               rate=self.map["precision_prior_rate"]))
         if self.reversible_jump:
             model.append(
                 Uniform(
-                    response="z_src",
+                    response=self.map["source_location"],
                     domain_response_lower=self.site_limits[:, [0]],
                     domain_response_upper=self.site_limits[:, [1]],
                 )
             )
-            model.append(Poisson(response="n_src", rate="rho"))
+            model.append(Poisson(response=self.map["number_sources"], rate=self.map["number_source_rate"]))
         return model
 
     def make_sampler(self, model: Model, sampler_list: list) -> list:
@@ -740,7 +778,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         sampler_list = self.make_source_sampler(model, sampler_list)
         sampler_list = self.make_allocation_sampler(model, sampler_list)
         if self.update_precision:
-            sampler_list.append(NormalGamma("lambda_s", model))
+            sampler_list.append(NormalGamma(self.map["emission_rate_precision"], model))
         if self.reversible_jump:
             sampler_list = self.make_sampler_rjmcmc(model, sampler_list)
         return sampler_list
@@ -757,15 +795,15 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         """
         state = self.make_allocation_state(state)
         state = self.make_source_state(state)
-        state["A"] = self.coupling
-        state["lambda_s"] = np.array(self.initial_precision, ndmin=1)
+        state[self.map["coupling_matrix"]] = self.coupling
+        state[self.map["emission_rate_precision"]] = np.array(self.initial_precision, ndmin=1)
         if self.update_precision:
-            state["a_lam_s"] = np.ones_like(self.initial_precision) * self.prior_precision_shape
-            state["b_lam_s"] = np.ones_like(self.initial_precision) * self.prior_precision_rate
+            state[self.map["precision_prior_shape"]] = np.ones_like(self.initial_precision) * self.prior_precision_shape
+            state[self.map["precision_prior_rate"]] = np.ones_like(self.initial_precision) * self.prior_precision_rate
         if self.reversible_jump:
-            state["z_src"] = self.dispersion_model.source_map.location.to_array().T
-            state["n_src"] = state["z_src"].shape[1]
-            state["rho"] = self.rate_num_sources
+            state[self.map["source_location"]] = self.dispersion_model.source_map.location.to_array().T
+            state[self.map["number_sources"]] = state[self.map["source_location"]].shape[1]
+            state[self.map["number_source_rate"]] = self.rate_num_sources
         return state
 
     def make_sampler_rjmcmc(self, model: Model, sampler_list: list) -> list:
@@ -789,7 +827,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
 
         sampler_list.append(
             RandomWalkLoop(
-                "z_src",
+                self.map["source_location"],
                 model,
                 step=self.random_walk_step_size,
                 max_variable_size=(3, self.n_sources_max),
@@ -797,13 +835,14 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
                 state_update_function=self.move_function,
             )
         )
-        matching_params = {"variable": "s", "matrix": "A", "scale": 1.0, "limits": [0.0, 1e6]}
+        matching_params = {"variable": self.map["source"], "matrix": self.map["coupling_matrix"],
+                           "scale": 1.0, "limits": [0.0, 1e6]}
         sampler_list.append(
             ReversibleJump(
-                "n_src",
+                self.map["number_sources"],
                 model,
                 step=np.array([1.0], ndmin=2),
-                associated_params="z_src",
+                associated_params=self.map["source_location"],
                 n_max=self.n_sources_max,
                 state_birth_function=self.birth_function,
                 state_death_function=self.death_function,
@@ -822,7 +861,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         self.from_mcmc_group(store)
         self.from_mcmc_dist(store)
         if self.update_precision:
-            self.precision_scalar = store["lambda_s"]
+            self.precision_scalar = store[self.map["emission_rate_precision"]]
 
     def plot_iterations(self, plot: "Plot", burn_in_value: int, y_axis_type: str = "linear") -> "Plot":
         """Plot the emission rate estimates source model object against MCMC iteration.

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -19,7 +19,7 @@ A SourceModel instance inherits from 3 super-classes:
 from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Tuple, Union, Dict
 
 import numpy as np
 from openmcmc import parameter
@@ -46,18 +46,19 @@ class ParameterMapping:
     """ Class for defining mapping variable/parameterised labels needed for creating an mcmc
 
     """
-    map = {'source': 's',
-           'coupling_matrix': 'A',
-           'emission_rate_mean':'mu_s',
-           'emission_rate_precision': 'lambda_s',
-           'allocation': 'alloc_s',
-           'source_prob': 's_prob',
-           'precision_prior_shape': 'a_lam_s',
-           'precision_prior_rate': 'b_lam_s',
-           "source_location": 'z_src',
-           'number_sources': 'n_src',
-           "number_source_rate": 'rho'}
-
+    map : Dict = field(default_factory==
+                      {'source': 's',
+                       'coupling_matrix': 'A',
+                        'emission_rate_mean':'mu_s',
+                        'emission_rate_precision': 'lambda_s',
+                        'allocation': 'alloc_s',
+                        'source_prob': 's_prob',
+                        'precision_prior_shape': 'a_lam_s',
+                        'precision_prior_rate': 'b_lam_s',
+                        "source_location": 'z_src',
+                        'number_sources': 'n_src',
+                        "number_source_rate": 'rho'})
+                      
     def append_string(self, string: str=None):
         """ Append string to all element of map
 
@@ -487,7 +488,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
         threshold_function (Callable): Callable function which returns a single value that defines the threshold
             for the coupling in a lambda function form. Examples: lambda x: np.quantile(x, 0.95, axis=0),
             lambda x: np.max(x, axis=0), lambda x: np.mean(x, axis=0). Defaults to np.quantile.
-
+        label_string (str): string to append to the parameter mapping, e.g. for fixed sources.
     """
 
     dispersion_model: GaussianPlume = field(init=False, default=None)
@@ -514,6 +515,12 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
     coverage_test_source: float = 6.0
 
     threshold_function: callable = lambda x: np.quantile(x, 0.95, axis=0)
+
+    label_string: str = None 
+
+    def __post_init__(self):
+        if self.label_string is not None:
+            self.append_string(self.label_string)
 
     @property
     def nof_sources(self):

--- a/src/pyelq/component/source_model.py
+++ b/src/pyelq/component/source_model.py
@@ -46,25 +46,27 @@ class ParameterMapping:
     """ Class for defining mapping variable/parameterised labels needed for creating an mcmc
 
     """
-    map : Dict = field(default_factory==
-                      {'source': 's',
-                       'coupling_matrix': 'A',
+
+    map : dict = field(default_factory =lambda:
+                       {'source': 's',
+                        'coupling_matrix': 'A',
                         'emission_rate_mean':'mu_s',
                         'emission_rate_precision': 'lambda_s',
                         'allocation': 'alloc_s',
                         'source_prob': 's_prob',
                         'precision_prior_shape': 'a_lam_s',
                         'precision_prior_rate': 'b_lam_s',
-                        "source_location": 'z_src',
+                        'source_location': 'z_src',
                         'number_sources': 'n_src',
-                        "number_source_rate": 'rho'})
-                      
+                        'number_source_rate': 'rho'}
+                        )
+
     def append_string(self, string: str=None):
         """ Append string to all element of map
 
         e.g. 'source': 's' would become 'source': 's_fixed' with string = 'fixed'
 
-        If string is None nothing is appended
+        If string is None, nothing is appended.
 
         Args:
             string (str): string to append
@@ -516,7 +518,7 @@ class SourceModel(Component, SourceGrouping, SourceDistribution):
 
     threshold_function: callable = lambda x: np.quantile(x, 0.95, axis=0)
 
-    label_string: str = None 
+    label_string: str = None
 
     def __post_init__(self):
         if self.label_string is not None:

--- a/src/pyelq/model.py
+++ b/src/pyelq/model.py
@@ -65,6 +65,7 @@ class ELQModel:
         source_model: SourceModel = Normal(),
         error_model: ErrorModel = BySensor(),
         offset_model: PerSensor = None,
+        source_model_fixed : SourceModel = None
     ):
         """Initialise the ELQModel model.
 
@@ -85,6 +86,7 @@ class ELQModel:
             source_model (SourceModel): source model specification. Defaults to Normal().
             error_model (Precision): measurement precision model specification. Defaults to BySensor().
             offset_model (PerSensor): offset model specification. Defaults to None.
+            source_model_fixed (SourceModel): fixed source model specification. Defaults to None.
 
         """
         self.sensor_object = sensor_object
@@ -95,6 +97,7 @@ class ELQModel:
             "source": source_model,
             "error_model": error_model,
             "offset": offset_model,
+            "source_fixed": source_model_fixed,
         }
         if error_model is None:
             self.components["error_model"] = BySensor()
@@ -112,11 +115,17 @@ class ELQModel:
             self.form["bg"] = "B_bg"
             self.transform["bg"] = False
         if "source" in component_keys:
-            self.transform["s"] = False
-            self.form["s"] = "A"
+            source_component_map = self.components["source"].map
+            self.transform[source_component_map["source"]] = False
+            self.form[source_component_map["source"]] = source_component_map["coupling_matrix"]
         if "offset" in component_keys:
             self.form["d"] = "B_d"
             self.transform["d"] = False
+        if "source_fixed" in component_keys:
+            source_component_map_fixed =self.components["source_fixed"].map
+            self.transform[source_component_map_fixed["source"]] = False
+            self.form[source_component_map_fixed["source"]] = source_component_map_fixed["coupling_matrix"]
+
         for key in component_keys:
             self.components[key].initialise(self.sensor_object, self.meteorology, self.gas_species)
 

--- a/src/pyelq/model.py
+++ b/src/pyelq/model.py
@@ -65,7 +65,6 @@ class ELQModel:
         source_model: SourceModel = Normal(),
         error_model: ErrorModel = BySensor(),
         offset_model: PerSensor = None,
-        source_model_fixed: SourceModel = None,
     ):
         """Initialise the ELQModel model.
 
@@ -86,7 +85,6 @@ class ELQModel:
             source_model (SourceModel): source model specification. Defaults to Normal().
             error_model (Precision): measurement precision model specification. Defaults to BySensor().
             offset_model (PerSensor): offset model specification. Defaults to None.
-            source_model_fixed (SourceModel): fixed source model specification. Defaults to None.
 
         """
         self.sensor_object = sensor_object
@@ -97,7 +95,6 @@ class ELQModel:
             "source": source_model,
             "error_model": error_model,
             "offset": offset_model,
-            "source_fixed": source_model_fixed,
         }
         if error_model is None:
             self.components["error_model"] = BySensor()
@@ -115,17 +112,11 @@ class ELQModel:
             self.form["bg"] = "B_bg"
             self.transform["bg"] = False
         if "source" in component_keys:
-            source_component_map = self.components["source"].map
-            self.transform[source_component_map["source"]] = False
-            self.form[source_component_map["source"]] = source_component_map["coupling_matrix"]
+            self.transform["s"] = False
+            self.form["s"] = "A"
         if "offset" in component_keys:
             self.form["d"] = "B_d"
             self.transform["d"] = False
-        if "source_fixed" in component_keys:
-            source_component_map = self.components["source_fixed"].map
-            self.transform[source_component_map["source"]] = False
-            self.form[source_component_map["source"]] = source_component_map["coupling_matrix"]
-
         for key in component_keys:
             self.components[key].initialise(self.sensor_object, self.meteorology, self.gas_species)
 

--- a/src/pyelq/model.py
+++ b/src/pyelq/model.py
@@ -65,6 +65,7 @@ class ELQModel:
         source_model: SourceModel = Normal(),
         error_model: ErrorModel = BySensor(),
         offset_model: PerSensor = None,
+        source_model_fixed: SourceModel = None,
     ):
         """Initialise the ELQModel model.
 
@@ -85,6 +86,7 @@ class ELQModel:
             source_model (SourceModel): source model specification. Defaults to Normal().
             error_model (Precision): measurement precision model specification. Defaults to BySensor().
             offset_model (PerSensor): offset model specification. Defaults to None.
+            source_model_fixed (SourceModel): fixed source model specification. Defaults to None.
 
         """
         self.sensor_object = sensor_object
@@ -95,6 +97,7 @@ class ELQModel:
             "source": source_model,
             "error_model": error_model,
             "offset": offset_model,
+            "source_fixed": source_model_fixed,
         }
         if error_model is None:
             self.components["error_model"] = BySensor()
@@ -112,11 +115,17 @@ class ELQModel:
             self.form["bg"] = "B_bg"
             self.transform["bg"] = False
         if "source" in component_keys:
-            self.transform["s"] = False
-            self.form["s"] = "A"
+            source_component_map = self.components["source"].map
+            self.transform[source_component_map["source"]] = False
+            self.form[source_component_map["source"]] = source_component_map["coupling_matrix"]
         if "offset" in component_keys:
             self.form["d"] = "B_d"
             self.transform["d"] = False
+        if "source_fixed" in component_keys:
+            source_component_map = self.components["source_fixed"].map
+            self.transform[source_component_map["source"]] = False
+            self.form[source_component_map["source"]] = source_component_map["coupling_matrix"]
+
         for key in component_keys:
             self.components[key].initialise(self.sensor_object, self.meteorology, self.gas_species)
 


### PR DESCRIPTION
# Description

This pull request is for adding a new feature to pyELQ enabling the use of fixed sources and reversible jump simultaneously. 
With this functionality a use can provide a list of location for the fixed sources in which the emission rate will be estimated for them and their location is assumed to be fixed. The reversible jump functionality explores the area for remaining potential emission sources. 

For the implementation we create "ParameterMapping" class to map the map the variables or parameterized labels needed for creating the mcmc. Therefore, the "map" dictionary is dynamic and its values can be changed by appending a string to the default "map".  

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Jupyter Notebooks

If your changes involve Jupyter notebooks please explicitly state here what the change consists of, e.g. only output cells have changes or specific input changes. This to make sure we capture these changes correctly in the review process.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

