### PR TITLE
Fix mask source

### DIFF
--- a/src/pyelq/dispersion_model/finite_volume.py
+++ b/src/pyelq/dispersion_model/finite_volume.py
@@ -307,13 +307,14 @@ class FiniteVolume(DispersionModel):
             _, id_obstacles = self.site_layout.find_index_obstacles(self.source_map.location)
         else:
             id_obstacles = np.zeros((self.source_map.nof_sources, 1), dtype=bool)
+        id_obstacles = id_obstacles.flatten()
         for key, sensor in sensor_object.items():
             interpolated_coupling[key] = np.full((sensor.time.shape[0], source_location.shape[0]), fill_value=0.0)
             lookup_table_values = self.coupling_lookup_table[key].T
             interpolated_coupling[key] = self._build_interpolator(
                 lookup_table_values, locations_to_interpolate=source_location
             ).T
-            interpolated_coupling[key][:, id_obstacles.flatten()] = 0
+            interpolated_coupling[key][:, id_obstacles] = 0
         return interpolated_coupling
 
     def propagate_solver_single_time_step(

--- a/src/pyelq/dispersion_model/finite_volume.py
+++ b/src/pyelq/dispersion_model/finite_volume.py
@@ -103,7 +103,7 @@ class FiniteVolume(DispersionModel):
         self.number_dimensions = len(self.dimensions)
         self._setup_grid()
         if self.site_layout is not None:
-            self.site_layout.find_index_obstacles(self.grid_coordinates)
+            self.site_layout.set_index_obstacles_grid(self.grid_coordinates)
         self._setup_neighbourhood()
 
     def compute_coupling(
@@ -303,12 +303,14 @@ class FiniteVolume(DispersionModel):
         """
         interpolated_coupling = {}
         source_location = self.source_map.location.to_array(dim=self.number_dimensions)
+        _, id_obstacles = self.site_layout.find_index_obstacles(self.source_map.location)
         for key, sensor in sensor_object.items():
             interpolated_coupling[key] = np.full((sensor.time.shape[0], source_location.shape[0]), fill_value=0.0)
             lookup_table_values = self.coupling_lookup_table[key].T
             interpolated_coupling[key] = self._build_interpolator(
                 lookup_table_values, locations_to_interpolate=source_location
             ).T
+            interpolated_coupling[key][:, id_obstacles.flatten()] = 0
         return interpolated_coupling
 
     def propagate_solver_single_time_step(

--- a/src/pyelq/dispersion_model/finite_volume.py
+++ b/src/pyelq/dispersion_model/finite_volume.py
@@ -303,7 +303,10 @@ class FiniteVolume(DispersionModel):
         """
         interpolated_coupling = {}
         source_location = self.source_map.location.to_array(dim=self.number_dimensions)
-        _, id_obstacles = self.site_layout.find_index_obstacles(self.source_map.location)
+        if self.site_layout is not None:
+            _, id_obstacles = self.site_layout.find_index_obstacles(self.source_map.location)
+        else:
+            id_obstacles = np.zeros((self.source_map.nof_sources, 1), dtype=bool)
         for key, sensor in sensor_object.items():
             interpolated_coupling[key] = np.full((sensor.time.shape[0], source_location.shape[0]), fill_value=0.0)
             lookup_table_values = self.coupling_lookup_table[key].T

--- a/src/pyelq/dispersion_model/site_layout.py
+++ b/src/pyelq/dispersion_model/site_layout.py
@@ -48,8 +48,8 @@ class SiteLayout:
             return 0
         return self.cylinder_coordinates.nof_observations
 
-    def find_index_obstacles(self, grid_coordinates: ENU):
-        """Find the indices of the grid_coordinates that are within the radius of the obstacles.
+    def find_index_obstacles(self, coordinates: ENU):
+        """Find the indices of the coordinates that are within the radius of the obstacles.
 
         This method uses a KDTree to efficiently find the indices of the grid points that are within the radius of the
         cylindrical obstacles. It also checks the height of the grid points against the height of the obstacles.
@@ -60,25 +60,29 @@ class SiteLayout:
 
         """
         if self.cylinder_coordinates is None or self.cylinder_coordinates.nof_observations == 0:
-            self.id_obstacles = np.zeros((grid_coordinates.nof_observations, 1), dtype=bool)
+            self.id_obstacles = np.zeros((coordinates.nof_observations, 1), dtype=bool)
             return
 
-        self.check_reference_coordinates(grid_coordinates)
+        self.check_reference_coordinates(coordinates)
 
-        grid_coordinates_array = grid_coordinates.to_array(dim=2)
-        tree = spatial.KDTree(grid_coordinates_array)
+        coordinates_array = coordinates.to_array(dim=2)
+        tree = spatial.KDTree(coordinates_array)
         indices = tree.query_ball_point(x=self.cylinder_coordinates.to_array(dim=2), r=self.cylinder_radius.flatten())
 
-        if grid_coordinates.up is not None:
+        if coordinates.up is not None:
 
             for i, height in enumerate(self.cylinder_coordinates.up):
                 indices[i] = np.array(indices[i])
                 if len(indices[i]) > 0:
-                    indices[i] = indices[i][grid_coordinates.up[indices[i]].flatten() <= height]
+                    indices[i] = indices[i][coordinates.up[indices[i]].flatten() <= height]
         indices_conc = np.unique(np.concatenate(indices, axis=0)).astype(int)
-        self.id_obstacles_index = indices_conc
-        self.id_obstacles = np.zeros((grid_coordinates.nof_observations, 1), dtype=bool)
-        self.id_obstacles[[indices_conc]] = True
+        id_obstacles_index = indices_conc
+        id_obstacles = np.zeros((coordinates.nof_observations, 1), dtype=bool)
+        id_obstacles[[indices_conc]] = True
+        return id_obstacles_index, id_obstacles
+    
+    def set_index_obstacles_grid(self, grid_coordinates: ENU):
+        self.id_obstacles_index, self.id_obstacles = self.find_index_obstacles(grid_coordinates)
 
     def check_reference_coordinates(self, grid_coordinates: ENU):
         """Check if the reference coordinates of the grid and cylinder coordinates match.

--- a/src/pyelq/dispersion_model/site_layout.py
+++ b/src/pyelq/dispersion_model/site_layout.py
@@ -11,7 +11,7 @@ This module defines the SiteLayout class, which represents the layout of a site,
 """
 
 from dataclasses import dataclass, field
-from typing import Union, Tuple
+from typing import Tuple, Union
 
 import numpy as np
 from scipy import spatial
@@ -84,10 +84,10 @@ class SiteLayout:
         id_obstacles = np.zeros((coordinates.nof_observations, 1), dtype=bool)
         id_obstacles[[indices_conc]] = True
         return id_obstacles_index, id_obstacles
-    
+
     def set_index_obstacles_grid(self, grid_coordinates: ENU):
         """Set the indices of the grid points that are within obstacle regions based on the grid coordinates.
-        
+
         Args:
             grid_coordinates (ENU): The coordinates of the grid points to check.
 

--- a/src/pyelq/dispersion_model/site_layout.py
+++ b/src/pyelq/dispersion_model/site_layout.py
@@ -11,7 +11,7 @@ This module defines the SiteLayout class, which represents the layout of a site,
 """
 
 from dataclasses import dataclass, field
-from typing import Union
+from typing import Union, Tuple
 
 import numpy as np
 from scipy import spatial
@@ -48,20 +48,24 @@ class SiteLayout:
             return 0
         return self.cylinder_coordinates.nof_observations
 
-    def find_index_obstacles(self, coordinates: ENU):
+    def find_index_obstacles(self, coordinates: ENU) -> Tuple[np.ndarray, np.ndarray]:
         """Find the indices of the coordinates that are within the radius of the obstacles.
 
-        This method uses a KDTree to efficiently find the indices of the grid points that are within the radius of the
-        cylindrical obstacles. It also checks the height of the grid points against the height of the obstacles.
-        If the height of the grid point is greater than the height of the obstacle, it is not considered an obstacle.
+        This method uses a KDTree to efficiently find the indices of the points that are within the radius of the
+        cylindrical obstacles. It also checks the height of the points against the height of the obstacles.
+        If the height of the point is greater than the height of the obstacle, it is not considered an obstacle.
 
         Args:
-            grid_coordinates (ENU): The coordinates of the grid points to check.
+            coordinates (ENU): The coordinates of the points to check.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: A tuple containing the indices of the points that are within the obstacles
+            and a boolean array indicating which points are within obstacles.
 
         """
         if self.cylinder_coordinates is None or self.cylinder_coordinates.nof_observations == 0:
-            self.id_obstacles = np.zeros((coordinates.nof_observations, 1), dtype=bool)
-            return
+            id_obstacles = np.zeros((coordinates.nof_observations, 1), dtype=bool)
+            return np.array([], dtype=int), id_obstacles
 
         self.check_reference_coordinates(coordinates)
 
@@ -82,20 +86,26 @@ class SiteLayout:
         return id_obstacles_index, id_obstacles
     
     def set_index_obstacles_grid(self, grid_coordinates: ENU):
-        self.id_obstacles_index, self.id_obstacles = self.find_index_obstacles(grid_coordinates)
-
-    def check_reference_coordinates(self, grid_coordinates: ENU):
-        """Check if the reference coordinates of the grid and cylinder coordinates match.
-
+        """Set the indices of the grid points that are within obstacle regions based on the grid coordinates.
+        
         Args:
             grid_coordinates (ENU): The coordinates of the grid points to check.
+
+        """
+        self.id_obstacles_index, self.id_obstacles = self.find_index_obstacles(grid_coordinates)
+
+    def check_reference_coordinates(self, coordinates: ENU):
+        """Check if the reference coordinates of the coordinates and cylinder coordinates match.
+
+        Args:
+            coordinates (ENU): The coordinates of the points to check.
 
         Raises:
             ValueError: If the reference coordinates do not match.
         """
-        if grid_coordinates.ref_altitude != self.cylinder_coordinates.ref_altitude:
-            raise ValueError("Grid coordinates and cylinder coordinates must have the same reference altitude.")
-        if grid_coordinates.ref_longitude != self.cylinder_coordinates.ref_longitude:
-            raise ValueError("Grid coordinates and cylinder coordinates must have the same reference longitude.")
-        if grid_coordinates.ref_latitude != self.cylinder_coordinates.ref_latitude:
-            raise ValueError("Grid coordinates and cylinder coordinates must have the same reference latitude.")
+        if coordinates.ref_altitude != self.cylinder_coordinates.ref_altitude:
+            raise ValueError("Coordinates and cylinder coordinates must have the same reference altitude.")
+        if coordinates.ref_longitude != self.cylinder_coordinates.ref_longitude:
+            raise ValueError("Coordinates and cylinder coordinates must have the same reference longitude.")
+        if coordinates.ref_latitude != self.cylinder_coordinates.ref_latitude:
+            raise ValueError("Coordinates and cylinder coordinates must have the same reference latitude.")

--- a/tests/meteorology/test_meteorology_windfield.py
+++ b/tests/meteorology/test_meteorology_windfield.py
@@ -39,6 +39,7 @@ def fixture_grid_coordinates():
         ref_altitude=0,
     )
 
+
 @pytest.fixture(params=[0, 10, 20], ids=["0-m", "10-m", "20-m"], name="height")
 def fixture_height(request):
     """Fixture for the cylinder heights."""
@@ -92,6 +93,7 @@ def test_set_index_obstacles_grid(site_layout, grid_coordinates, height):
     site_layout.set_index_obstacles_grid(site_layout.cylinder_coordinates)
     assert np.all(site_layout.id_obstacles)
 
+
 def test_find_index_obstacles(site_layout, height):
     """Test the find_index_obstacles method of SiteLayout.
 
@@ -100,7 +102,7 @@ def test_find_index_obstacles(site_layout, height):
     Check that coordinates that are in the cylinders are identified as obstacles, and that coordinates that are not
     in the cylinders are not identified as obstacles. I also check that coordinates that their 2D location is in the
     cylinder but are above the height of the cylinders are not identified as obstacles.
-    
+
     """
     coordinates = ENU(
         east=np.array([0.5, 0.5, 0.5, 5.0]),
@@ -108,8 +110,8 @@ def test_find_index_obstacles(site_layout, height):
         up=np.array([0, 2.0, 25, 0]),
         ref_latitude=0,
         ref_longitude=0,
-        ref_altitude=0
-        )
+        ref_altitude=0,
+    )
     _, id_obstacles = site_layout.find_index_obstacles(coordinates)
     if site_layout.cylinder_coordinates.nof_observations > 0:
         if height == 0:
@@ -118,6 +120,7 @@ def test_find_index_obstacles(site_layout, height):
             assert np.array_equal(id_obstacles, np.array([[True, True, False, False]]).T)
     else:
         assert np.array_equal(id_obstacles, np.array([[False, False, False, False]]).T)
+
 
 def test_meteorology_windfield(meteorology_windfield, meteorology, grid_coordinates):
     """Test the MeteorologyWindfield class.

--- a/tests/meteorology/test_meteorology_windfield.py
+++ b/tests/meteorology/test_meteorology_windfield.py
@@ -39,18 +39,6 @@ def fixture_grid_coordinates():
         ref_altitude=0,
     )
 
-@pytest.fixture(name="coordinates")
-def fixture_coordinates():
-    """Fixture for coordinates."""
-    return ENU(
-        east=np.array([0.5, 0.5, 0.5, 5.0]),
-        north=np.array([0, 0, 0, 0]),
-        up=np.array([0, 2.0, 25, 0]),
-        ref_latitude=0,
-        ref_longitude=0,
-        ref_altitude=0,
-    )
-
 @pytest.fixture(params=[0, 10, 20], ids=["0-m", "10-m", "20-m"], name="height")
 def fixture_height(request):
     """Fixture for the cylinder heights."""

--- a/tests/meteorology/test_meteorology_windfield.py
+++ b/tests/meteorology/test_meteorology_windfield.py
@@ -39,6 +39,17 @@ def fixture_grid_coordinates():
         ref_altitude=0,
     )
 
+@pytest.fixture(name="coordinates")
+def fixture_coordinates():
+    """Fixture for coordinates."""
+    return ENU(
+        east=np.array([0.5, 0.5, 0.5, 5.0]),
+        north=np.array([0, 0, 0, 0]),
+        up=np.array([0, 2.0, 25, 0]),
+        ref_latitude=0,
+        ref_longitude=0,
+        ref_altitude=0,
+    )
 
 @pytest.fixture(params=[0, 10, 20], ids=["0-m", "10-m", "20-m"], name="height")
 def fixture_height(request):
@@ -66,7 +77,7 @@ def fixture_site_layout(request, height, grid_coordinates):
         ),
         cylinder_radius=radius,
     )
-    site_layout.find_index_obstacles(grid_coordinates)
+    site_layout.set_index_obstacles_grid(grid_coordinates)
     return site_layout
 
 
@@ -76,8 +87,8 @@ def fixture_meteorology_windfield(site_layout, meteorology):
     return MeteorologyWindfield(site_layout=site_layout, static_wind_field=meteorology)
 
 
-def test_find_index_obstacles(site_layout, grid_coordinates, height):
-    """Test the find_index_obstacles method of SiteLayout.
+def test_set_index_obstacles_grid(site_layout, grid_coordinates, height):
+    """Test the set_index_obstacles_grid method of SiteLayout.
 
     Test the method with different cylinder configurations and check the output.
 
@@ -90,9 +101,28 @@ def test_find_index_obstacles(site_layout, grid_coordinates, height):
     assert site_layout.id_obstacles.shape == (grid_coordinates.nof_observations, 1)
     assert site_layout.id_obstacles.dtype == bool
     assert not np.any(site_layout.id_obstacles[grid_coordinates.up > height])
-    site_layout.find_index_obstacles(site_layout.cylinder_coordinates)
+    site_layout.set_index_obstacles_grid(site_layout.cylinder_coordinates)
     assert np.all(site_layout.id_obstacles)
 
+def test_find_index_obstacles(site_layout, coordinates, height):
+    """Test the find_index_obstacles method of SiteLayout.
+
+    Test the method with different cylinder configurations and check the output.
+
+    Check that grid points above the height of the cylinders are not considered obstacles.
+
+    Pass cylinder locations in as grid coordinates and check that the method correctly identifies them as obstacles or
+    not.
+
+    """
+    _, id_obstacles = site_layout.find_index_obstacles(coordinates)
+    if site_layout.cylinder_coordinates.nof_observations > 0:
+        if height == 0:
+            assert np.array_equal(id_obstacles, np.array([[True, False, False, False]]).T)
+        elif height == 10 or height == 20:
+            assert np.array_equal(id_obstacles, np.array([[True, True, False, False]]).T)
+    else:
+        assert np.array_equal(id_obstacles, np.array([[False, False, False, False]]).T)
 
 def test_meteorology_windfield(meteorology_windfield, meteorology, grid_coordinates):
     """Test the MeteorologyWindfield class.

--- a/tests/meteorology/test_meteorology_windfield.py
+++ b/tests/meteorology/test_meteorology_windfield.py
@@ -104,17 +104,24 @@ def test_set_index_obstacles_grid(site_layout, grid_coordinates, height):
     site_layout.set_index_obstacles_grid(site_layout.cylinder_coordinates)
     assert np.all(site_layout.id_obstacles)
 
-def test_find_index_obstacles(site_layout, coordinates, height):
+def test_find_index_obstacles(site_layout, height):
     """Test the find_index_obstacles method of SiteLayout.
 
-    Test the method with different cylinder configurations and check the output.
+    Test the method with different coordinates and cylinder configurations and check the output.
 
-    Check that grid points above the height of the cylinders are not considered obstacles.
-
-    Pass cylinder locations in as grid coordinates and check that the method correctly identifies them as obstacles or
-    not.
-
+    Check that coordinates that are in the cylinders are identified as obstacles, and that coordinates that are not
+    in the cylinders are not identified as obstacles. I also check that coordinates that their 2D location is in the
+    cylinder but are above the height of the cylinders are not identified as obstacles.
+    
     """
+    coordinates = ENU(
+        east=np.array([0.5, 0.5, 0.5, 5.0]),
+        north=np.array([0, 0, 0, 0]),
+        up=np.array([0, 2.0, 25, 0]),
+        ref_latitude=0,
+        ref_longitude=0,
+        ref_altitude=0
+        )
     _, id_obstacles = site_layout.find_index_obstacles(coordinates)
     if site_layout.cylinder_coordinates.nof_observations > 0:
         if height == 0:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Shell Global Solutions International B.V. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0
-->

# Description

Add a functionality in finite_volume to zero out the columns of the coupling matrix corresponding to source terms that fall within obstacle regions. This ensures that sources located inside obstacles are effectively excluded from the coupling matrix.
Changes are as the following: 
1) SiteLayout Class (site_layout.py):
**Refactor find_index_obstacles:** 
- Updated to accept generic coordinates instead of grid_coordinates, improving flexibility and enabling use with arbitrary ENU coordinate inputs.
- The method no longer stores id_obstacles and id_obstacles_index as class attributes. Instead, it returns these as NumPy arrays.
**Add set_index_obstacles_grid:**
- New wrapper method around find_index_obstacles for grid-coordinates.
- Stores id_obstacles and id_obstacles_index as SiteLayout class attributes for grid_coordinates.
**Update check_reference_coordinates**
- Renamed input argument from grid_coordinate to coordinates for consistency with the refactor.

2) FiniteVolume Class (finite_volume.py):
**Modify interpolate_coupling_lookup_to_source_map:**
- For a given source_map.location, the method now calls find_index_obstacles to determine which sources fall inside obstacles.
- Uses the returned boolean array id_obstacles to zero out corresponding columns in the interpolated_coupling dictionary.

3) test_meteorology_windfield.py
Added a new test to explicitly check the behavior of find_index_obstacles.
The test covers four coordinates:
One point always inside the cylinder regardless of height.
One point inside the cylinder only when the height is 10 or 20 meters.
Two other points are located outside the obstacles. 

Fixes # (issue)
Fixes the issue of non-zero coupling values when a source is located inside a cylindrical obstacle. Physically, the coupling should be zero in such cases. However, the current implementation computes coupling values using linear interpolation of neighboring points without enforcing this constraint. As a result, interpolated values may remain non-zero even when the source lies within an obstacle.
To address this, we now intervene after the interpolation where coupling values are explicitly set to zero for the sources located inside cylindrical obstacles. This ensures physically consistent behavior of the coupling matrix.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Jupyter Notebooks

No changes is made to the existing Jupyter Notebooks
# How Has This Been Tested?

- [x] Test A: Existing test_find_index_obstacles is refactored to check the behavior of find_index_obstacles with four sets of coordinates. 
- [x] Test B: The test_set_index_obstacles_grid is added to check the behavior of the wrapper function for a given grid coordinates.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
